### PR TITLE
docs: Fix godoc.org links in exported name comments.

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Native is the of list `transformer.Transformer` to apply to a native AST.
-// To learn more about the Transformers and the available ones take a look to:
-// https://godoc.org/github.com/bblfsh/sdk/v3/uast/transformer
+// To learn more about the Transformers and to see the available ones, read
+// https://godoc.org/github.com/bblfsh/sdk/uast/transformer.
 var Native = Transformers([][]Transformer{
 	// The main block of transformation rules.
 	{Mappings(Annotations...)},
@@ -25,7 +25,7 @@ var Native = Transformers([][]Transformer{
 // and can access original source code file. It can be used to improve or
 // fix positional information.
 //
-// https://godoc.org/github.com/bblfsh/sdk/v3/uast/transformer/positioner
+// https://godoc.org/github.com/bblfsh/sdk/uast/transformer/positioner
 var PreprocessCode = []CodeTransformer{
 	positioner.FromUTF16Offset(),
 	positioner.TokenFromSource{


### PR DESCRIPTION
An extension of https://github.com/bblfsh/go-driver/issues/48.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/csharp-driver/41)
<!-- Reviewable:end -->
